### PR TITLE
Changing the input data check in the base selector class

### DIFF
--- a/skcosmo/_selection.py
+++ b/skcosmo/_selection.py
@@ -151,27 +151,26 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         elif self.progress_bar is False:
             self.report_progress = no_progress_bar
 
+        params = dict(
+            accept_sparse="csc",
+            force_all_finite=not tags.get("allow_nan", True),
+        )
+        if self._axis == 1:
+            params["ensure_min_features"] = 2
+        else:
+            params["ensure_min_samples"] = 2
+
         if y is not None:
-            X, y = self._validate_data(
-                X,
-                y,
-                accept_sparse="csc",
-                ensure_min_features=2,
-                force_all_finite=not tags.get("allow_nan", True),
-                multi_output=True,
-            )
+            params["multi_output"] = True
+            X, y = self._validate_data(X, y, **params)
+
             if len(y.shape) == 1:
                 # force y to have multi_output 2D format even when it's 1D, since
                 # many functions, most notably PCov routines, assume an array storage
                 # format, most notably to compute (y @ y.T)
                 y = y.reshape((len(y), 1))
         else:
-            X = check_array(
-                X,
-                accept_sparse="csc",
-                ensure_min_features=2,
-                force_all_finite=not tags.get("allow_nan", True),
-            )
+            X = check_array(X, **params)
 
         n_to_select_from = X.shape[self._axis]
 

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -113,6 +113,26 @@ class TestGreedy(unittest.TestCase):
         Xr = selector.transform(self.X)
         self.assertEqual(Xr.shape[1], self.X.shape[1] // 2)
 
+    def test_size_input(self):
+        X = np.array([1, 2, 3, 4, 5]).reshape(-1, 1)
+        selector_sample = GreedyTester(selection_type="sample")
+        selector_feature = GreedyTester(selection_type="feature")
+        selector_sample.fit(X)
+        with self.assertRaises(ValueError) as cm:
+            selector_feature.fit(X)
+            self.assertEqual(
+                str(cm.message),
+                "Found array with 1 feature(s) (shape=(5, 1)) while a minimum of 2 is required.",
+            )
+        X = X.reshape(1, -1)
+        selector_feature.fit(X)
+        with self.assertRaises(ValueError) as cm:
+            selector_sample.fit(X)
+            self.assertEqual(
+                str(cm.message),
+                "Found array with 1 sample(s) (shape=(1, 5)) while a minimum of 2 is required.",
+            )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
This is a continuation of #117. In this PR a separation was added when checking the data. In the case where a sample selection is made, it is checked that there will be at least two samples. If there is feature selection, the same is checked for features. 