### PR TITLE
Allow to use a relative score threshold, which can detect identical points passed to FPS

### DIFF
--- a/skcosmo/feature_selection/_base.py
+++ b/skcosmo/feature_selection/_base.py
@@ -32,6 +32,13 @@ class FPS(_FPS):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -57,6 +64,7 @@ class FPS(_FPS):
         initialize=0,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -66,6 +74,7 @@ class FPS(_FPS):
             initialize=initialize,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,
@@ -98,6 +107,13 @@ class PCovFPS(_PCovFPS):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -124,6 +140,7 @@ class PCovFPS(_PCovFPS):
         initialize=0,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -134,6 +151,7 @@ class PCovFPS(_PCovFPS):
             initialize=initialize,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,
@@ -168,6 +186,13 @@ class CUR(_CUR):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -198,6 +223,7 @@ class CUR(_CUR):
         tolerance=1e-12,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -209,6 +235,7 @@ class CUR(_CUR):
             tolerance=tolerance,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,
@@ -247,6 +274,13 @@ class PCovCUR(_PCovCUR):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -282,6 +316,7 @@ class PCovCUR(_PCovCUR):
         tolerance=1e-12,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -294,6 +329,7 @@ class PCovCUR(_PCovCUR):
             tolerance=tolerance,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,

--- a/skcosmo/sample_selection/_base.py
+++ b/skcosmo/sample_selection/_base.py
@@ -32,6 +32,13 @@ class FPS(_FPS):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -59,6 +66,7 @@ class FPS(_FPS):
         initialize=0,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -68,6 +76,7 @@ class FPS(_FPS):
             initialize=initialize,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,
@@ -100,6 +109,13 @@ class PCovFPS(_PCovFPS):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -129,6 +145,7 @@ class PCovFPS(_PCovFPS):
         initialize=0,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -139,6 +156,7 @@ class PCovFPS(_PCovFPS):
             initialize=initialize,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,
@@ -172,6 +190,13 @@ class CUR(_CUR):
          n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
          Stored in :py:attr:`self.score_threshold`.
 
+     score_threshold_type : str, default="absolute"
+         How to interpret the ``score_threshold``. When "absolute", the score used by
+         the selector is compared to the threshold directly. When "relative", at each iteration,
+         the score used by the selector is compared proportionally to the score of the first
+         selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+         Stored in :py:attr:`self.score_threshold_type`.
+
      progress_bar: bool, default=False
                option to use `tqdm <https://tqdm.github.io/>`_
                progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -204,6 +229,7 @@ class CUR(_CUR):
         tolerance=1e-12,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -215,6 +241,7 @@ class CUR(_CUR):
             tolerance=tolerance,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,
@@ -254,6 +281,13 @@ class PCovCUR(_PCovCUR):
         n_to_select is chosen. Otherwise will stop when the score falls below the threshold.
         Stored in :py:attr:`self.score_threshold`.
 
+    score_threshold_type : str, default="absolute"
+        How to interpret the ``score_threshold``. When "absolute", the score used by
+        the selector is compared to the threshold directly. When "relative", at each iteration,
+        the score used by the selector is compared proportionally to the score of the first
+        selection, i.e. the selector quits when ``current_score / first_score < threshold``.
+        Stored in :py:attr:`self.score_threshold_type`.
+
     progress_bar: bool, default=False
               option to use `tqdm <https://tqdm.github.io/>`_
               progress bar to monitor selections. Stored in :py:attr:`self.report_progress`.
@@ -291,6 +325,7 @@ class PCovCUR(_PCovCUR):
         tolerance=1e-12,
         n_to_select=None,
         score_threshold=None,
+        score_threshold_type="absolute",
         progress_bar=False,
         full=False,
         random_state=0,
@@ -303,6 +338,7 @@ class PCovCUR(_PCovCUR):
             tolerance=tolerance,
             n_to_select=n_to_select,
             score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
             progress_bar=progress_bar,
             full=full,
             random_state=random_state,

--- a/tests/test_sample_simple_fps.py
+++ b/tests/test_sample_simple_fps.py
@@ -62,6 +62,25 @@ class TestFPS(unittest.TestCase):
             selector = FPS(n_to_select=1)
             _ = selector.get_select_distance()
 
+    def test_threshold(self):
+        selector = FPS(
+            n_to_select=10,
+            score_threshold=5e-2,
+            score_threshold_type="absolute",
+        )
+        selector.fit(self.X)
+        self.assertEqual(len(selector.selected_idx_), 6)
+        self.assertEqual(selector.selected_idx_.tolist(), self.idx[:6])
+
+        selector = FPS(
+            n_to_select=10,
+            score_threshold=0.4,
+            score_threshold_type="relative",
+        )
+        selector.fit(self.X)
+        self.assertEqual(len(selector.selected_idx_), 5)
+        self.assertEqual(selector.selected_idx_.tolist(), self.idx[:5])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #128 

I'm not sure if this is the best approach to do so, but I think this is a case we want to detect automatically by default.

Score thresholding seems like it would be useful here as well, but since it works using absolute values, we can not enable it by default without knowing about the magnitude of features.  

I could also modify score thresholding to work with relative scores, and use that instead.