### PR TITLE
Fix docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,7 +209,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "skcosmo.tex", u"scikit-COSMO Documentation", author, "manual"),
+    (master_doc, "skcosmo.tex", "scikit-COSMO Documentation", author, "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,8 +81,6 @@ extensions = [
 
 nbsphinx_execute = "never"
 
-source_suffix = [".rst", ".ipynb"]
-
 # If set to False return type and description are put into one paragraph
 napoleon_use_rtype = False
 

--- a/examples/PlotLFRE.ipynb
+++ b/examples/PlotLFRE.ipynb
@@ -140,7 +140,7 @@
     "ax34.set_title(r\"$X^-$ LFRE(3-body, 4-body)\")\n",
     "ax43.set_title(r\"$X^-$ LFRE(4-body, 3-body)\")\n",
     "\n",
-    "cbar = fig.colorbar(pcm, ax=(ax34, ax43), label=\"LFRE\", location=\"bottom\")\n",
+    "cbar = fig.colorbar(pcm, ax=[ax34, ax43], label=\"LFRE\", location=\"bottom\")\n",
     "\n",
     "plt.show()"
    ]

--- a/examples/PlotPointwiseGFRE.ipynb
+++ b/examples/PlotPointwiseGFRE.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
-    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Pointwise-Global-Feature-Reconstruction-Error-(pointwise-GFRE)\" data-toc-modified-id=\"Pointwise-Global-Feature-Reconstruction-Error-(pointwise-GFRE)-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Powintwise Global Feature Reconstruction Error (pointwise GFRE) applied on RKHS features</a></span></li></ul></div>"
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Pointwise-GFRE-applied-on-RKHS-features\" data-toc-modified-id=\"Pointwise-GFRE-applied-on-RKHS-features-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Pointwise GFRE applied on RKHS features</a></span></li></ul></div>"
    ]
   },
   {


### PR DESCRIPTION
In this PR I've fixed a few outstanding issues with the docs, namely:

- error in building the examples on RTD
- formatting issue in `docs/source/conf.py`
- error in building `PlotLFRE.ipynb`