### PR TITLE
Fix example in `StandardFlexibleScaler` class

### DIFF
--- a/skcosmo/preprocessing/_data.py
+++ b/skcosmo/preprocessing/_data.py
@@ -82,11 +82,11 @@ class StandardFlexibleScaler(TransformerMixin, BaseEstimator):
 
     Examples
     --------
-    >>> import numpy
+    >>> import numpy as np
     >>> from skcosmo.preprocessing import StandardFlexibleScaler
     >>> X = np.array([[ 1., -2.,  2.],
-    ...      [ -2.,  1.,  3.],
-    ...      [ 4.,  1., -2.]])
+    ...               [-2.,  1.,  3.],
+    ...               [ 4.,  1., -2.]])
     >>> transformer = StandardFlexibleScaler().fit(X)
     >>> transformer
     StandardFlexibleScaler()
@@ -102,7 +102,6 @@ class StandardFlexibleScaler(TransformerMixin, BaseEstimator):
         array([[ 1., -2.,  2.],
                [-2.,  1.,  3.],
                [ 4.,  1., -2.]])
-    >>>
     """
 
     def __init__(


### PR DESCRIPTION
The example of the `StandardFlexibleScaler` class does not work as given in the example due to a minor naming issue.