### PR TITLE
Remove python 3.7 support from tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ commands =
 
 [testenv:examples]
 changedir = examples
-allowlist_externals = /bin/bash
+allowlist_externals = bash
 
 deps = -rexamples/requirements.txt
 


### PR DESCRIPTION
Python 3.7 has cause problem due to issues with the sklearn diabetes dataset and Python 3.7 support has been dropped since last year according to NEP

From discussion in
https://github.com/lab-cosmo/scikit-cosmo/pull/140#discussion_r1042238012
