### PR TITLE
Changed python version to 3.8 for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
In PR #146 we forgot to remove python 3.7 support from ReadTheDocs. Here we update it to the correct python version 3.8.