### PR TITLE
Fix indentation errors in tests

### DIFF
--- a/skcosmo/preprocessing/_data.py
+++ b/skcosmo/preprocessing/_data.py
@@ -505,7 +505,7 @@ class SparseKernelCenterer(TransformerMixin, BaseEstimator):
 
         if Knm.shape[1] != Kmm.shape[0]:
             raise ValueError(
-                "The reference kernel is not commensurate shape with the"
+                "The reference kernel is not commensurate shape with the "
                 "active kernel."
             )
 

--- a/skcosmo/sample_selection/_voronoi_fps.py
+++ b/skcosmo/sample_selection/_voronoi_fps.py
@@ -184,13 +184,13 @@ class VoronoiFPS(GreedySelector):
             if isinstance(self.full_fraction, numbers.Real):
                 if not 0 < self.full_fraction <= 1:
                     raise ValueError(
-                        "Switching point should be real and more than 0 and less than 1",
-                        f"received {self.full_fraction}",
+                        "Switching point should be real and more than 0 and less than 1. "
+                        f"Received {self.full_fraction}"
                     )
             else:
                 raise ValueError(
-                    "Switching point should be real and more than 0 and less than 1",
-                    f"received {self.full_fraction}",
+                    "Switching point should be real and more than 0 and less than 1. "
+                    f"Received {self.full_fraction}"
                 )
 
         super()._init_greedy_search(X, y, n_to_select)

--- a/tests/test_feature_pcov_fps.py
+++ b/tests/test_feature_pcov_fps.py
@@ -31,11 +31,10 @@ class TestPCovFPS(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             _ = PCovFPS(n_to_select=1, mixing=1.0)
-            self.assertEquals(
-                str(cm.message),
-                "Mixing = 1.0 corresponds to traditional FPS."
-                "Please use the FPS class.",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "Mixing = 1.0 corresponds to traditional FPS." "Please use the FPS class.",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_feature_simple_fps.py
+++ b/tests/test_feature_simple_fps.py
@@ -45,9 +45,9 @@ class TestFPS(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             selector = FPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
-            self.assertEquals(
-                str(cm.exception), "Invalid value of the initialize parameter"
-            )
+        self.assertEqual(
+            str(cm.exception), "Invalid value of the initialize parameter"
+        )
 
     def test_get_distances(self):
         """

--- a/tests/test_feature_simple_fps.py
+++ b/tests/test_feature_simple_fps.py
@@ -46,7 +46,7 @@ class TestFPS(unittest.TestCase):
             selector = FPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
             self.assertEquals(
-                str(cm.message), "Invalid value of the initialize parameter"
+                str(cm.exception), "Invalid value of the initialize parameter"
             )
 
     def test_get_distances(self):

--- a/tests/test_feature_simple_fps.py
+++ b/tests/test_feature_simple_fps.py
@@ -45,9 +45,7 @@ class TestFPS(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             selector = FPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
-        self.assertEqual(
-            str(cm.exception), "Invalid value of the initialize parameter"
-        )
+        self.assertEqual(str(cm.exception), "Invalid value of the initialize parameter")
 
     def test_get_distances(self):
         """

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -44,19 +44,19 @@ class TestGreedy(unittest.TestCase):
     def test_score_threshold_and_full(self):
         with self.assertRaises(ValueError) as cm:
             _ = GreedyTester(score_threshold=20, full=True, n_to_select=12).fit(self.X)
-            self.assertEqual(
-                str(cm.message),
-                "You cannot specify both `score_threshold` and `full=True`.",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "You cannot specify both `score_threshold` and `full=True`.",
+        )
 
     def test_bad_warm_start(self):
         selector = GreedyTester()
         with self.assertRaises(ValueError) as cm:
             selector.fit(self.X, warm_start=True)
-            self.assertTrue(
-                str(cm.message),
-                "Cannot fit with warm_start=True without having been previously initialized",
-            )
+        self.assertTrue(
+            str(cm.exception),
+            "Cannot fit with warm_start=True without having been previously initialized",
+        )
 
     def test_bad_y(self):
         self.X, self.Y = get_dataset(return_X_y=True)
@@ -66,11 +66,12 @@ class TestGreedy(unittest.TestCase):
 
     def test_bad_transform(self):
         selector = GreedyTester(n_to_select=2)
+        selector.fit(self.X)
         with self.assertRaises(ValueError) as cm:
             _ = selector.transform(self.X[:, :3])
-            self.assertEqual(
-                str(cm.message), "X has a different shape than during fitting."
-            )
+        self.assertEqual(
+            str(cm.exception), "X has a different shape than during fitting."
+        )
 
     def test_no_nfeatures(self):
         selector = GreedyTester()
@@ -88,17 +89,16 @@ class TestGreedy(unittest.TestCase):
                 selector = GreedyTester(n_to_select=nf)
                 with self.assertRaises(ValueError) as cm:
                     selector.fit(self.X)
-                    self.assertEqual(
-                        str(cm.message),
-                        (
-                            "n_to_select must be either None, an "
-                            "integer in [1, n_features - 1] "
-                            "representing the absolute "
-                            "number of features, or a float in (0, 1] "
-                            "representing a percentage of features to "
-                            f"select. Got {nf}"
-                        ),
-                    )
+                self.assertEqual(
+                    str(cm.exception),
+                    (
+                        "n_to_select must be either None, an integer in "
+                        "[1, n_features] representing the absolute number "
+                        "of features, or a float in (0, 1] representing a "
+                        f"percentage of features to select. Got {nf} "
+                        f"features and an input with {self.X.shape[1]} feature."
+                    ),
+                )
 
     def test_not_fitted(self):
         with self.assertRaises(NotFittedError):
@@ -120,18 +120,18 @@ class TestGreedy(unittest.TestCase):
         selector_sample.fit(X)
         with self.assertRaises(ValueError) as cm:
             selector_feature.fit(X)
-            self.assertEqual(
-                str(cm.message),
-                "Found array with 1 feature(s) (shape=(5, 1)) while a minimum of 2 is required.",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "Found array with 1 feature(s) (shape=(5, 1)) while a minimum of 2 is required.",
+        )
         X = X.reshape(1, -1)
         selector_feature.fit(X)
         with self.assertRaises(ValueError) as cm:
             selector_sample.fit(X)
-            self.assertEqual(
-                str(cm.message),
-                "Found array with 1 sample(s) (shape=(1, 5)) while a minimum of 2 is required.",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "Found array with 1 sample(s) (shape=(1, 5)) while a minimum of 2 is required.",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_pcovr.py
+++ b/tests/test_kernel_pcovr.py
@@ -233,13 +233,13 @@ class KernelPCovRInfrastructureTest(KernelPCovRBaseTest):
         # kernel parameters now inconsistent
         with self.assertRaises(ValueError) as cm:
             kpcovr.fit(self.X, self.Y)
-            self.assertTrue(
-                str(cm.message),
-                "Kernel parameter mismatch: the regressor has kernel parameters "
-                "{kernel: linear, gamma: 0.2, degree: 3, coef0: 1, kernel_params: None}"
-                " and KernelPCovR was initialized with kernel parameters "
-                "{kernel: linear, gamma: 0.1, degree: 3, coef0: 1, kernel_params: None}",
-            )
+        self.assertTrue(
+            str(cm.exception),
+            "Kernel parameter mismatch: the regressor has kernel parameters "
+            "{kernel: linear, gamma: 0.2, degree: 3, coef0: 1, kernel_params: None}"
+            " and KernelPCovR was initialized with kernel parameters "
+            "{kernel: linear, gamma: 0.1, degree: 3, coef0: 1, kernel_params: None}",
+        )
 
     def test_incompatible_regressor(self):
         regressor = Ridge(alpha=1e-8)
@@ -248,10 +248,10 @@ class KernelPCovRInfrastructureTest(KernelPCovRBaseTest):
 
         with self.assertRaises(ValueError) as cm:
             kpcovr.fit(self.X, self.Y)
-            self.assertTrue(
-                str(cm.message),
-                "Regressor must be an instance of `KernelRidge`",
-            )
+        self.assertTrue(
+            str(cm.exception),
+            "Regressor must be an instance of `KernelRidge`",
+        )
 
     def test_none_regressor(self):
         kpcovr = KernelPCovR(mixing=0.5, regressor=None)
@@ -271,24 +271,24 @@ class KernelPCovRInfrastructureTest(KernelPCovRBaseTest):
         # Dimension mismatch
         with self.assertRaises(ValueError) as cm:
             kpcovr.fit(self.X, self.Y[:, 0])
-            self.assertTrue(
-                str(cm.message),
-                "The regressor coefficients have a dimension incompatible "
-                "with the supplied target space. "
-                "The coefficients have dimension %d and the targets "
-                "have dimension %d" % (regressor.dual_coef_.ndim, self.Y[:, 0].ndim),
-            )
+        self.assertTrue(
+            str(cm.exception),
+            "The regressor coefficients have a dimension incompatible "
+            "with the supplied target space. "
+            "The coefficients have dimension %d and the targets "
+            "have dimension %d" % (regressor.dual_coef_.ndim, self.Y[:, 0].ndim),
+        )
 
         # Shape mismatch (number of targets)
         with self.assertRaises(ValueError) as cm:
             kpcovr.fit(self.X, self.Y)
-            self.assertTrue(
-                str(cm.message),
-                "The regressor coefficients have a shape incompatible "
-                "with the supplied target space. "
-                "The coefficients have shape %r and the targets "
-                "have shape %r" % (regressor.dual_coef_.shape, self.Y.shape),
-            )
+        self.assertTrue(
+            str(cm.exception),
+            "The regressor coefficients have a shape incompatible "
+            "with the supplied target space. "
+            "The coefficients have shape %r and the targets "
+            "have shape %r" % (regressor.dual_coef_.shape, self.Y.shape),
+        )
 
     def test_precomputed_regression(self):
         regressor = KernelRidge(alpha=1e-8, kernel="rbf", gamma=0.1)
@@ -424,7 +424,7 @@ class KernelPCovRTestSVDSolvers(KernelPCovRBaseTest):
             kpcovr = self.model(svd_solver="bad")
             kpcovr.fit(self.X, self.Y)
 
-            self.assertTrue(str(cm.message), "Unrecognized svd_solver='bad'" "")
+        self.assertTrue(str(cm.exception), "Unrecognized svd_solver='bad'" "")
 
     def test_good_n_components(self):
         """
@@ -457,60 +457,60 @@ class KernelPCovRTestSVDSolvers(KernelPCovRBaseTest):
                 kpcovr = self.model(n_components=-1, svd_solver="auto")
                 kpcovr.fit(self.X, self.Y)
 
-                self.assertTrue(
-                    str(cm.message),
-                    "self.n_components=%r must be between 0 and "
-                    "min(n_samples, n_features)=%r with "
-                    "svd_solver='%s'"
-                    % (
-                        kpcovr.n_components,
-                        self.X.shape[0],
-                        kpcovr.svd_solver,
-                    ),
-                )
+            self.assertTrue(
+                str(cm.exception),
+                "self.n_components=%r must be between 0 and "
+                "min(n_samples, n_features)=%r with "
+                "svd_solver='%s'"
+                % (
+                    kpcovr.n_components,
+                    self.X.shape[0],
+                    kpcovr.svd_solver,
+                ),
+            )
         with self.subTest(type="0_ncomponents"):
             with self.assertRaises(ValueError) as cm:
                 kpcovr = self.model(n_components=0, svd_solver="randomized")
                 kpcovr.fit(self.X, self.Y)
 
-                self.assertTrue(
-                    str(cm.message),
-                    "self.n_components=%r must be between 1 and "
-                    "min(n_samples, n_features)=%r with "
-                    "svd_solver='%s'"
-                    % (
-                        kpcovr.n_components,
-                        self.X.shape[0],
-                        kpcovr.svd_solver,
-                    ),
-                )
+            self.assertTrue(
+                str(cm.exception),
+                "self.n_components=%r must be between 1 and "
+                "min(n_samples, n_features)=%r with "
+                "svd_solver='%s'"
+                % (
+                    kpcovr.n_components,
+                    self.X.shape[0],
+                    kpcovr.svd_solver,
+                ),
+            )
         with self.subTest(type="arpack_X_ncomponents"):
             with self.assertRaises(ValueError) as cm:
                 kpcovr = self.model(n_components=self.X.shape[0], svd_solver="arpack")
                 kpcovr.fit(self.X, self.Y)
-                self.assertTrue(
-                    str(cm.message),
-                    "self.n_components=%r must be strictly less than "
-                    "min(n_samples, n_features)=%r with "
-                    "svd_solver='%s'"
-                    % (
-                        kpcovr.n_components,
-                        self.X.shape[0],
-                        kpcovr.svd_solver,
-                    ),
-                )
+            self.assertTrue(
+                str(cm.exception),
+                "self.n_components=%r must be strictly less than "
+                "min(n_samples, n_features)=%r with "
+                "svd_solver='%s'"
+                % (
+                    kpcovr.n_components,
+                    self.X.shape[0],
+                    kpcovr.svd_solver,
+                ),
+            )
 
         for svd_solver in ["auto", "full"]:
             with self.subTest(type="pi_ncomponents"):
                 with self.assertRaises(ValueError) as cm:
                     kpcovr = self.model(n_components=np.pi, svd_solver=svd_solver)
                     kpcovr.fit(self.X, self.Y)
-                    self.assertTrue(
-                        str(cm.message),
-                        "self.n_components=%r must be of type int "
-                        "when greater than or equal to 1, was of type=%r"
-                        % (kpcovr.n_components, type(kpcovr.n_components)),
-                    )
+                self.assertTrue(
+                    str(cm.exception),
+                    "self.n_components=%r must be of type int "
+                    "when greater than or equal to 1, was of type=%r"
+                    % (kpcovr.n_components, type(kpcovr.n_components)),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_orthogonalizers.py
+++ b/tests/test_orthogonalizers.py
@@ -131,11 +131,11 @@ class TestXOrth(unittest.TestCase):
                     -3, 3, size=(self.n_samples + 4, self.n_features)
                 ),
             )
-            self.assertEqual(
-                str(cm.exception),
-                "You can only orthogonalize a matrix using a vector with the same number of rows."
-                f"Matrix X has {self.n_samples} rows, whereas the orthogonalizing matrix has {self.n_samples+4} rows.",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "You can only orthogonalize a matrix using a vector with the same number of rows."
+            f"Matrix X has {self.n_samples} rows, whereas the orthogonalizing matrix has {self.n_samples+4} rows.",
+        )
 
     def test_warning(self):
         # checks that a warning is raised when trying to orthogonalize by

--- a/tests/test_orthogonalizers.py
+++ b/tests/test_orthogonalizers.py
@@ -132,7 +132,7 @@ class TestXOrth(unittest.TestCase):
                 ),
             )
             self.assertEqual(
-                str(cm.message),
+                str(cm.exception),
                 "You can only orthogonalize a matrix using a vector with the same number of rows."
                 f"Matrix X has {self.n_samples} rows, whereas the orthogonalizing matrix has {self.n_samples+4} rows.",
             )

--- a/tests/test_pcovr.py
+++ b/tests/test_pcovr.py
@@ -272,7 +272,7 @@ class PCovRTestSVDSolvers(PCovRBaseTest):
                 pcovr = self.model(svd_solver="bad", space=space)
                 pcovr.fit(self.X, self.Y)
 
-                self.assertTrue(str(cm.message), "Unrecognized svd_solver='bad'" "")
+            self.assertEqual(str(cm.exception), "Unrecognized svd_solver='bad'" "")
 
     def test_good_n_components(self):
         """
@@ -303,71 +303,70 @@ class PCovRTestSVDSolvers(PCovRBaseTest):
         with self.assertRaises(ValueError) as cm:
             pcovr = self.model(n_components="mle", svd_solver="full")
             pcovr.fit(self.X[:2], self.Y[:2])
-            self.assertEqual(
-                str(cm.message),
-                "self.n_components='mle' is only supported "
-                "if n_samples >= n_features",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "n_components='mle' is only supported " "if n_samples >= n_features",
+        )
 
         with self.subTest(type="negative_ncomponents"):
             with self.assertRaises(ValueError) as cm:
                 pcovr = self.model(n_components=-1, svd_solver="auto")
                 pcovr.fit(self.X, self.Y)
 
-                self.assertTrue(
-                    str(cm.message),
-                    "self.n_components=%r must be between 0 and "
-                    "min(n_samples, n_features)=%r with "
-                    "svd_solver='%s'"
-                    % (
-                        pcovr.n_components,
-                        min(self.X.shape),
-                        pcovr.svd_solver,
-                    ),
-                )
+            self.assertEqual(
+                str(cm.exception),
+                "n_components=%r must be between 1 and "
+                "min(n_samples, n_features)=%r with "
+                "svd_solver='%s'"
+                % (
+                    pcovr.n_components,
+                    min(self.X.shape),
+                    pcovr.svd_solver,
+                ),
+            )
         with self.subTest(type="0_ncomponents"):
             with self.assertRaises(ValueError) as cm:
                 pcovr = self.model(n_components=0, svd_solver="randomized")
                 pcovr.fit(self.X, self.Y)
 
-                self.assertTrue(
-                    str(cm.message),
-                    "self.n_components=%r must be between 1 and "
-                    "min(n_samples, n_features)=%r with "
-                    "svd_solver='%s'"
-                    % (
-                        pcovr.n_components,
-                        min(self.X.shape),
-                        pcovr.svd_solver,
-                    ),
-                )
+            self.assertEqual(
+                str(cm.exception),
+                "n_components=%r must be between 1 and "
+                "min(n_samples, n_features)=%r with "
+                "svd_solver='%s'"
+                % (
+                    pcovr.n_components,
+                    min(self.X.shape),
+                    pcovr.svd_solver,
+                ),
+            )
         with self.subTest(type="arpack_X_ncomponents"):
             with self.assertRaises(ValueError) as cm:
                 pcovr = self.model(n_components=min(self.X.shape), svd_solver="arpack")
                 pcovr.fit(self.X, self.Y)
-                self.assertTrue(
-                    str(cm.message),
-                    "self.n_components=%r must be strictly less than "
-                    "min(n_samples, n_features)=%r with "
-                    "svd_solver='%s'"
-                    % (
-                        pcovr.n_components,
-                        min(self.X.shape),
-                        pcovr.svd_solver,
-                    ),
-                )
+            self.assertEqual(
+                str(cm.exception),
+                "n_components=%r must be strictly less than "
+                "min(n_samples, n_features)=%r with "
+                "svd_solver='%s'"
+                % (
+                    pcovr.n_components,
+                    min(self.X.shape),
+                    pcovr.svd_solver,
+                ),
+            )
 
         for svd_solver in ["auto", "full"]:
             with self.subTest(type="pi_ncomponents"):
                 with self.assertRaises(ValueError) as cm:
                     pcovr = self.model(n_components=np.pi, svd_solver=svd_solver)
                     pcovr.fit(self.X, self.Y)
-                    self.assertTrue(
-                        str(cm.message),
-                        "self.n_components=%r must be of type int "
-                        "when greater than or equal to 1, was of type=%r"
-                        % (pcovr.n_components, type(pcovr.n_components)),
-                    )
+                self.assertEqual(
+                    str(cm.exception),
+                    "n_components=%r must be of type int "
+                    "when greater than or equal to 1, was of type=%r"
+                    % (pcovr.n_components, type(pcovr.n_components)),
+                )
 
 
 class PCovRInfrastructureTest(PCovRBaseTest):
@@ -476,11 +475,12 @@ class PCovRInfrastructureTest(PCovRBaseTest):
 
         with self.assertRaises(ValueError) as cm:
             pcovr.fit(self.X, self.Y)
-            self.assertTrue(
-                str(cm.message),
-                "Regressor must be an instance of "
-                "`LinearRegression`, `Ridge`, or `RidgeCV`",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "Regressor must be an instance of "
+            "`LinearRegression`, `Ridge`, `RidgeCV`, "
+            "or `precomputed`",
+        )
 
     def test_none_regressor(self):
         pcovr = PCovR(mixing=0.5, regressor=None)
@@ -500,25 +500,25 @@ class PCovRInfrastructureTest(PCovRBaseTest):
         # Dimension mismatch
         with self.assertRaises(ValueError) as cm:
             pcovr.fit(self.X, self.Y.squeeze())
-            self.assertTrue(
-                str(cm.message),
-                "The regressor coefficients have a dimension incompatible "
-                "with the supplied target space. "
-                "The coefficients have dimension %d and the targets "
-                "have dimension %d" % (regressor.coef_.ndim, self.Y.squeeze().ndim),
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "The regressor coefficients have a dimension incompatible "
+            "with the supplied target space. "
+            "The coefficients have dimension %d and the targets "
+            "have dimension %d" % (regressor.coef_.ndim, self.Y.squeeze().ndim),
+        )
 
         # Shape mismatch (number of targets)
         with self.assertRaises(ValueError) as cm:
             pcovr.fit(self.X, np.column_stack((self.Y, self.Y)))
-            self.assertTrue(
-                str(cm.message),
-                "The regressor coefficients have a shape incompatible "
-                "with the supplied target space. "
-                "The coefficients have shape %r and the targets "
-                "have shape %r"
-                % (regressor.coef_.shape, np.column_stack((self.Y, self.Y)).shape),
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "The regressor coefficients have a shape incompatible "
+            "with the supplied target space. "
+            "The coefficients have shape %r and the targets "
+            "have shape %r"
+            % (regressor.coef_.shape, np.column_stack((self.Y, self.Y)).shape),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -15,12 +15,12 @@ class PBarTest(unittest.TestCase):
 
         with self.assertRaises(ImportError) as cm:
             _ = get_progress_bar()
-            self.assertEqual(
-                str(cm.exception),
-                "tqdm must be installed to use a progress bar."
-                "Either install tqdm or re-run with"
-                "progress_bar = False",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "tqdm must be installed to use a progress bar."
+            "Either install tqdm or re-run with"
+            "progress_bar = False",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sample_pcov_fps.py
+++ b/tests/test_sample_pcov_fps.py
@@ -31,11 +31,10 @@ class TestPCovFPS(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             _ = PCovFPS(n_to_select=1, mixing=1.0)
-            self.assertEquals(
-                str(cm.message),
-                "Mixing = 1.0 corresponds to traditional FPS."
-                "Please use the FPS class.",
-            )
+        self.assertEquals(
+            str(cm.exception),
+            "Mixing = 1.0 corresponds to traditional FPS." "Please use the FPS class.",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sample_simple_fps.py
+++ b/tests/test_sample_simple_fps.py
@@ -46,9 +46,9 @@ class TestFPS(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             selector = FPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
-            self.assertEquals(
-                str(cm.message), "Invalid value of the initialize parameter"
-            )
+        self.assertEquals(
+            str(cm.exception), "Invalid value of the initialize parameter"
+        )
 
     def test_get_distances(self):
         """

--- a/tests/test_sparse_kernel_centerer.py
+++ b/tests/test_sparse_kernel_centerer.py
@@ -65,7 +65,7 @@ class SparseKernelTests(unittest.TestCase):
         model = SparseKernelCenterer()
         with self.assertRaises(ValueError) as cm:
             model.fit(Knm, Kmm)
-            self.assertEqual(str(cm.exception), "The active kernel is not square.")
+        self.assertEqual(str(cm.exception), "The active kernel is not square.")
 
     def test_LatterDim(self):
         """Checks that a matrix must have the same latter dimension as its active counterpart cannot be normalized."""
@@ -79,11 +79,10 @@ class SparseKernelTests(unittest.TestCase):
         model = SparseKernelCenterer()
         with self.assertRaises(ValueError) as cm:
             model.fit(Knm, Kmm)
-            self.assertEqual(
-                str(cm.exception),
-                "The reference kernel is not "
-                "commensurate shape with the active kernel.",
-            )
+        self.assertEqual(
+            str(cm.exception),
+            "The reference kernel is not " "commensurate shape with the active kernel.",
+        )
 
     def test_new_kernel(self):
         """Checks that it is impossible to normalize
@@ -99,10 +98,10 @@ class SparseKernelTests(unittest.TestCase):
         model = model.fit(Knm, Kmm)
         with self.assertRaises(ValueError) as cm:
             model.transform(Knm2)
-            self.assertEquals(
-                str(cm.exception),
-                "The reference kernel and received kernel have different shape",
-            )
+        self.assertEquals(
+            str(cm.exception),
+            "The reference kernel and received kernel have different shape",
+        )
 
     def test_NotFittedError_transform(self):
         """Checks that an error is returned when

--- a/tests/test_voronoi_fps.py
+++ b/tests/test_voronoi_fps.py
@@ -42,9 +42,9 @@ class TestVoronoiFPS(TestFPS):
         with self.assertRaises(ValueError) as cm:
             selector = VoronoiFPS(n_to_select=1, initialize="bad")
             selector.fit(self.X)
-            self.assertEquals(
-                str(cm.message), "Invalid value of the initialize parameter"
-            )
+        self.assertEquals(
+            str(cm.exception), "Invalid value of the initialize parameter"
+        )
 
     def test_switching_point(self):
         """
@@ -63,36 +63,38 @@ class TestVoronoiFPS(TestFPS):
             with self.assertRaises(ValueError) as cm:
                 selector = VoronoiFPS(n_to_select=1, n_trial_calculation=0)
                 selector.fit(self.X)
-                self.assertEquals(
-                    str(cm.message),
-                    "Number of trial calculation should be more or equal to 1",
-                )
+            self.assertEqual(
+                str(cm.exception),
+                "Number of trial calculation should be more or equal to 1",
+            )
 
         with self.subTest(name="float_ntrial"):
             with self.assertRaises(TypeError) as cm:
                 selector = VoronoiFPS(n_to_select=1, n_trial_calculation=0.3)
                 selector.fit(self.X)
-                self.assertEquals(
-                    str(cm.message), "Number of trial calculation should be integer"
-                )
+            self.assertEqual(
+                str(cm.exception), "Number of trial calculation should be integer"
+            )
 
         with self.subTest(name="large_ff"):
             with self.assertRaises(ValueError) as cm:
                 selector = VoronoiFPS(n_to_select=1, full_fraction=1.1)
                 selector.fit(self.X)
-                self.assertEquals(
-                    str(cm.message),
-                    f"Switching point should be real and more than 0 and less than 1 received {selector.full_fraction}",
-                )
+            self.assertEqual(
+                str(cm.exception),
+                "Switching point should be real and more than 0 and less than 1. "
+                f"Received {selector.full_fraction}",
+            )
 
         with self.subTest(name="string_ff"):
             with self.assertRaises(ValueError) as cm:
                 selector = VoronoiFPS(n_to_select=1, full_fraction="STRING")
                 selector.fit(self.X)
-                self.assertEquals(
-                    str(cm.message),
-                    f"Switching point should be real and more than 0 and less than 1 received {selector.full_fraction}",
-                )
+            self.assertEqual(
+                str(cm.exception),
+                "Switching point should be real and more than 0 and less than 1. "
+                f"Received {selector.full_fraction}",
+            )
 
     def test_get_distances(self):
         """


### PR DESCRIPTION
In lots of the tests, an exception was caught as shown below, with an assertEqual to ensure that the error message matches what the exception that is caught:
```python
with self.assertRaises(ValueError) as cm:
            _ = PCovFPS(n_to_select=1, mixing=1.0)
            self.assertEqual(
                str(cm.exception),
                "Mixing = 1.0 corresponds to traditional FPS." "Please use the FPS class.",
            )
```
However, when the exception is caught (at `_ = PCovFPS(n_to_select=1, mixing=1.0)` in the example above), the rest of the code in the `with` method does not execute, and so the assertEqual tests were not run.

I have fixed these indentation errors in the following manner, for the example above:

```python
with self.assertRaises(ValueError) as cm:
            _ = PCovFPS(n_to_select=1, mixing=1.0)
self.assertEqual(
    str(cm.exception),
    "Mixing = 1.0 corresponds to traditional FPS." "Please use the FPS class.",
)
```

Once the code executed properly, I additionally fixed some tests that were not functioning properly or raising warnings. Examples of errors that led to failed tests/warnings include:
- Using `self.assertTrue()` rather than `self.assertEqual()`
- Typos in the string passed to `self.assertEqual()`
- Using `self.assertEquals()` rather than `self.assertEqual()`(Deprecation warning)
- Forgetting to fit a GreedySelector in the test (when the test was not meant to check this error, obviously)

I also made some minor changes/typo fixes to error messages in the VoronoiFPS and SparseKernelCenterer classes.