### PR TITLE
Added deprecation warning to README and init file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 A collection of scikit-learn compatible utilities that implement methods
 developed in the COSMO laboratory
 
+## Deprecation Warning
+__IMPORTANT:__ This package has been renamed to scikit-matter (skmatter). This package will no longer be maintained and updated.
+
+Please install the new package, skmatter, using:
+
+```bash
+pip install skmatter
+```
+
 ## Installation
 
 ```bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 license_files = LICENSE
-author = Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin A. Helfrecht, Michele Ceriotti
+author = Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin A. Helfrecht, Victor P. Principe, Michele Ceriotti
 author_email = rose.cersonsky@epfl.ch
 description = A collection of scikit-learn compatible utilities that implement methods developed in the COSMO laboratory
 ; keywords =

--- a/skcosmo/__init__.py
+++ b/skcosmo/__init__.py
@@ -1,1 +1,9 @@
 __version__ = "0.1.2"
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+LOGGER.warn(
+    "DeprecationWarning: This package has been renamed to scikit-matter (skmatter). This package will no longer be maintained and updated. Please install the new package using `pip install skmatter`"
+)


### PR DESCRIPTION
Added warnings to README to say that scikit-cosmo (skcosmo) is deprecated and has been renamed to scikit-matter (skmatter), along with pip installation instructions.